### PR TITLE
Add changelog entry for 2026-03-20 documentation update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+Registro diário automático das mudanças identificadas no repositório, baseado em evidências concretas.
+
+## 2026-03-20
+
+### Documentação
+- `9571679` — adiciona artefatos e script para gerar uma página/resumo HTML em PDF do repositório UzzApp (`scripts/generate-app-summary-pdf.js`, `tmp/pdfs/uzzapp-app-summary.html`, `output/pdf/uzzapp-app-summary.pdf`)
+
+### Visual das mudanças
+
+```mermaid
+gitGraph
+    commit id: "base"
+
+    branch docs/repo-summary
+    checkout docs/repo-summary
+    commit id: "9571679"
+    checkout main
+    merge docs/repo-summary
+```
+
+> Gerado em: 2026-03-20


### PR DESCRIPTION
## Summary
- create `CHANGELOG.md` at the repository root
- record the 2026-03-20 documentation-related change based on commit `9571679`
- include a Mermaid `gitGraph` block to visualize the grouped change

## Testing
- Not run (not requested)